### PR TITLE
Removed features deprecated in django-hosts 1.0.

### DIFF
--- a/django_hosts/middleware.py
+++ b/django_hosts/middleware.py
@@ -10,7 +10,6 @@ class HostsBaseMiddleware(object):
     Adjust incoming request's urlconf based on hosts defined in
     settings.ROOT_HOSTCONF module.
     """
-    old_hosts_middleware = 'django_hosts.middleware.HostsMiddleware'
     new_hosts_middleware = 'django_hosts.middleware.HostsRequestMiddleware'
     toolbar_middleware = 'debug_toolbar.middleware.DebugToolbarMiddleware'
 
@@ -26,13 +25,8 @@ class HostsBaseMiddleware(object):
         middlewares = list(settings.MIDDLEWARE_CLASSES)
 
         show_exception = False
-        if (self.old_hosts_middleware in middlewares and
-                self.toolbar_middleware in middlewares):
-            show_exception = (middlewares.index(self.old_hosts_middleware) >
-                              middlewares.index(self.toolbar_middleware))
 
-        if not show_exception and (self.new_hosts_middleware in middlewares and
-                                   self.toolbar_middleware in middlewares):
+        if self.new_hosts_middleware in middlewares and self.toolbar_middleware in middlewares:
             show_exception = (middlewares.index(self.new_hosts_middleware) >
                               middlewares.index(self.toolbar_middleware))
 
@@ -90,17 +84,3 @@ class HostsResponseMiddleware(HostsBaseMiddleware):
 
         set_urlconf(host.urlconf)
         return response
-
-
-class HostsMiddleware(HostsRequestMiddleware):  # pragma: no cover
-    """
-    Provided for backwards-compatibility.
-    """
-    def __init__(self):
-        import warnings
-        warnings.warn("The 'django_hosts.middleware.HostsMiddleware' "
-                      "middleware has been split into HostsRequestMiddleware "
-                      "and HostsResponseMiddleware. Please consult the "
-                      "documentation and update your middleware settings.",
-                      PendingDeprecationWarning)
-        super(HostsMiddleware, self).__init__()

--- a/django_hosts/templatetags/hosts.py
+++ b/django_hosts/templatetags/hosts.py
@@ -1,5 +1,4 @@
 import re
-import warnings
 
 from django import template
 from django.conf import settings
@@ -136,13 +135,6 @@ def host_url(parser, token):
         port = parser.compile_filter(port)
 
     host, pivot, bits = fetch_arg(name, 'host', bits, consume=False)
-
-    if host is None:
-        host, pivot, bits = fetch_arg(name, 'on', bits, consume=False)
-        warnings.warn("The 'on' keyword of the '%s' template tag is pending "
-                      "deprecation in favor of the 'host' keyword. Please "
-                      "upgrade your templates accordingly.",
-                      PendingDeprecationWarning)
 
     if host:
         host = parser.compile_filter(host)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+2.0 (2016-xx-xx)
+----------------
+
+- **BACKWARD-INCOMPATIBLE** Removed the ``HostsMiddleware``, deprecated in
+  django-hosts 1.0.
+
 1.4 (2016-01-21)
 ----------------
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,9 @@ Changelog
 - **BACKWARD-INCOMPATIBLE** Removed the ``HostsMiddleware``, deprecated in
   django-hosts 1.0.
 
+- **BACKWARD-INCOMPATIBLE** Removed the ``on`` argument of the
+  ``{% host_url %}`` template tag, deprecated in django-hosts 1.0.
+
 1.4 (2016-01-21)
 ----------------
 

--- a/docs/templatetags.rst
+++ b/docs/templatetags.rst
@@ -5,11 +5,6 @@ Template tags
 
 .. function:: host_url(view_name, [view_args, view_kwargs], host_name, [host_args, host_kwargs, as_var, scheme])
 
-.. versionchanged:: 1.0
-
-   The ``on`` argument is now called ``host`` but will continue to work in
-   a deprecation cycle of two releases.
-
 Now if you want to actually refer to the full URLs in your templates
 you can use the included ``host_url`` template tag. So imagine having a
 host pattern of::

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -90,11 +90,3 @@ class MiddlewareTests(HostsTestCase):
         DEFAULT_HOST='multiple')
     def test_debug_toolbar_new_warning(self):
         self.assertRaises(ImproperlyConfigured, HostsRequestMiddleware)
-
-    @override_settings(
-        MIDDLEWARE_CLASSES=['debug_toolbar.middleware.DebugToolbarMiddleware',
-                            'django_hosts.middleware.HostsMiddleware'],
-        ROOT_HOSTCONF='tests.hosts.multiple',
-        DEFAULT_HOST='multiple')
-    def test_debug_toolbar_old_warning(self):
-        self.assertRaises(ImproperlyConfigured, HostsRequestMiddleware)


### PR DESCRIPTION
While these haven't been promoted to `DeprecationWarning`, they've been around longer than the promised two releases. I'd rather remove them then spend time trying to fix the latter warning as noted in https://github.com/jazzband/django-hosts/issues/51.