### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ django-hosts
    :target: https://coveralls.io/r/jazzband/django-hosts
 
 .. image:: https://readthedocs.org/projects/django-hosts/badge/?version=latest&style=flat
-   :target: http://django-hosts.readthedocs.org/en/latest/
+   :target: https://django-hosts.readthedocs.io/en/latest/
 
 .. image:: https://jazzband.co/static/img/badge.svg
    :target: https://jazzband.co/
@@ -95,4 +95,4 @@ Then configure your Django site to use the app:
    tag.
 
 .. _`repository on Github`: https://github.com/jazzband/django-hosts
-.. _`django-hosts.rtfd.org`: http://django-hosts.readthedocs.org/
+.. _`django-hosts.rtfd.org`: https://django-hosts.readthedocs.io/

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -185,7 +185,7 @@ Changelog
 
 - Extended tests dramatically (100% coverage).
 
-- Added docs at http://django-hosts.rtfd.org
+- Added docs at https://django-hosts.readthedocs.io
 
 - Stopped preventing the name 'default' for hosts.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -224,7 +224,7 @@ man_pages = [
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
-    'python': ('http://python.readthedocs.org/en/v2.7.2/', None),
+    'python': ('https://python.readthedocs.io/en/v2.7.2/', None),
     'django': (
         'https://docs.djangoproject.com/en/dev/',
         'https://docs.djangoproject.com/en/dev/_objects/',

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     long_description=read('README.rst'),
     use_scm_version=True,
     setup_requires=['setuptools_scm'],
-    url='http://django-hosts.rtfd.org/',
+    url='https://django-hosts.readthedocs.io/',
     author='Jannis Leidel',
     author_email='jannis@leidel.info',
     license='BSD',


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.