### PR TITLE
[travis] Cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,43 +1,52 @@
-dist: xenial
-sudo: false
 language: python
+
+sudo: false
+
 install:
 - pip install tox coveralls
+
 script:
 - tox
+
 matrix:
   include:
+  # Django 1.11 : Python 2.7, 3.4, 3.5, 3.6
   - python: 2.7
     env: TOXENV=py27-django-111
   - python: 3.4
     env: TOXENV=py34-django-111
+  - python: 3.5
+    env: TOXENV=py35-django-111
+  - python: 3.6
+    env: TOXENV=py36-django-111
+  - python: 3.7
+    env: TOXENV=py37-django-111
+  # Django 2.0 : Python 3.4, 3.5, 3.6, 3.7
   - python: 3.4
     env: TOXENV=py34-django-20
   - python: 3.5
-    env: TOXENV=py35-django-111
-  - python: 3.5
     env: TOXENV=py35-django-20
+  - python: 3.6
+    env: TOXENV=py36-django-20
+  - python: 3.7
+    env: TOXENV=py37-django-20
+  # Django 2.1 : Python 3.5, 3.6, 3.7
   - python: 3.5
     env: TOXENV=py35-django-21
+  - python: 3.6
+    env: TOXENV=py36-django-21
+  - python: 3.7
+    env: TOXENV=py37-django-21
+  # Django 2.2 : Python 3.5, 3.6, 3.7
   - python: 3.5
     env: TOXENV=py35-django-22
   - python: 3.6
-    env: TOXENV=py36-django-111
-  - python: 3.6
-    env: TOXENV=py36-django-20
-  - python: 3.6
-    env: TOXENV=py36-django-21
-  - python: 3.6
     env: TOXENV=py36-django-22
   - python: 3.7
-    env: TOXENV=py37-django-111
-  - python: 3.7
-    env: TOXENV=py37-django-20
-  - python: 3.7
-    env: TOXENV=py37-django-21
-  - python: 3.7
     env: TOXENV=py37-django-22
+
 after_success: coveralls
+
 deploy:
   provider: pypi
   server: https://jazzband.co/projects/django-hosts/upload

--- a/tox.ini
+++ b/tox.ini
@@ -8,12 +8,6 @@ envlist =
     py{35,36,37}-django-22
 
 [testenv]
-basepython =
-    py27: python2.7
-    py34: python3.4
-    py35: python3.5
-    py36: python3.6
-    py37: python3.7
 usedevelop = true
 commands = make test
 whitelist_externals = make


### PR DESCRIPTION
- xenial is default dist in travis
- no need to specify basepython
- reorder travis steps to match tox envs