### PR TITLE
removing deprecated modules django.utils.six and django.utils.lru_cache.lru_cache()

### DIFF
--- a/django_hosts/resolvers.py
+++ b/django_hosts/resolvers.py
@@ -14,7 +14,7 @@ from django.core.signals import setting_changed
 from django.urls import NoReverseMatch, reverse as reverse_path
 from django.utils.encoding import iri_to_uri, force_text
 from django.utils.functional import lazy
-from django.utils.lru_cache import lru_cache
+from functools import lru_cache
 from django.utils.regex_helper import normalize
 
 from .defaults import host as host_cls

--- a/django_hosts/resolvers.py
+++ b/django_hosts/resolvers.py
@@ -4,6 +4,7 @@ scheme, hostname and port you'll need to use the ``reverse`` and
 ``reverse_host`` helper functions (or its lazy cousins).
 """
 import re
+import six
 
 from importlib import import_module
 
@@ -11,7 +12,6 @@ from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.core.signals import setting_changed
 from django.urls import NoReverseMatch, reverse as reverse_path
-from django.utils import six
 from django.utils.encoding import iri_to_uri, force_text
 from django.utils.functional import lazy
 from django.utils.lru_cache import lru_cache

--- a/django_hosts/templatetags/hosts.py
+++ b/django_hosts/templatetags/hosts.py
@@ -1,9 +1,9 @@
 import re
+import six
 
 from django import template
 from django.conf import settings
 from django.template import TemplateSyntaxError
-from django.utils import six
 from django.template.base import FilterExpression
 from django.template.defaulttags import URLNode
 from django.utils.encoding import iri_to_uri, smart_str


### PR DESCRIPTION
django.utils.six and django.utils.lru_cache.lru_cache() were removed due to compatibility issues with python 2.
https://docs.djangoproject.com/en/3.0/releases/3.0/#removed-private-python-2-compatibility-apis