### PR TITLE
Replace ugettext_lazy with gettext_lazy

### DIFF
--- a/django_hosts/apps.py
+++ b/django_hosts/apps.py
@@ -1,6 +1,6 @@
 from django.apps import AppConfig
 from django.core import checks
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from .checks import check_default_host, check_root_hostconf
 


### PR DESCRIPTION
ugettext_lazy is deprecated in django 4.0: https://docs.djangoproject.com/en/dev/releases/3.0/#id3