### PR TITLE
Added support for Django 3.1

### DIFF
--- a/django_hosts/apps.py
+++ b/django_hosts/apps.py
@@ -1,6 +1,6 @@
 from django.apps import AppConfig
 from django.core import checks
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from .checks import check_default_host, check_root_hostconf
 

--- a/django_hosts/managers.py
+++ b/django_hosts/managers.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 from django.db import models
-from django.db.models.fields import FieldDoesNotExist
+from django.core.exceptions import FieldDoesNotExist
 
 
 class HostSiteManager(models.Manager):

--- a/docs/templatetags.rst
+++ b/docs/templatetags.rst
@@ -18,11 +18,11 @@ host pattern of::
 
 and a ``ROOT_URLCONF`` of::
 
-    from django.conf.urls import patterns, url
+    from django.urls import path
 
-    urlpatterns = patterns('mysite.admin',
-        url(r'^dashboard/$', 'dashboard', name='dashboard'),
-    )
+    urlpatterns = [
+        path('dashboard/', 'dashboard', name='dashboard'),
+    ]
 
 then this example will create a link to the admin dashboard:
 

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
         'Framework :: Django',
         'Framework :: Django :: 2.2',
         'Framework :: Django :: 3.0',
+        'Framework :: Django :: 3.1',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',

--- a/tests/urls/complex.py
+++ b/tests/urls/complex.py
@@ -1,6 +1,6 @@
-from django.conf.urls import url
+from django.urls import re_path
 from tests.views import test_view
 
 urlpatterns = [
-    url(r'^template/(?P<template>\w+)/$', test_view, name='complex-direct'),
+    re_path(r'^template/(?P<template>\w+)/$', test_view, name='complex-direct'),
 ]

--- a/tests/urls/multiple.py
+++ b/tests/urls/multiple.py
@@ -1,6 +1,6 @@
-from django.conf.urls import url
+from django.urls import path
 from django.shortcuts import render
 
 urlpatterns = [
-    url(r'^multiple/$', render, name='multiple-direct'),
+    path('multiple/', render, name='multiple-direct'),
 ]

--- a/tests/urls/simple.py
+++ b/tests/urls/simple.py
@@ -1,6 +1,6 @@
-from django.conf.urls import url
+from django.urls import path
 from django.shortcuts import render
 
 urlpatterns = [
-    url(r'^simple/$', render, name='simple-direct'),
+    path('simple/', render, name='simple-direct'),
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ args_are_paths = false
 envlist =
     py{35,36,37,38,39}-dj22
     py{36,37,38,39}-dj30
+    py{36,37,38,39}-dj31
 
 [testenv]
 usedevelop = true
@@ -12,6 +13,7 @@ whitelist_externals = make
 deps =
     dj22: Django>=2.2a1,<3.0
     dj30: Django>=3.0a1,<3.1
+    dj31: Django>=3.1a1,<3.2
     coverage
     flake8
     pytest-django


### PR DESCRIPTION
* FieldDoesNotExist has moved to django.core.exceptions
* ugettest_lazy() deprected if favor our gettext_lazy
* url() is deprecated in favor of path() and re_path()
* Added django3.1 to test matrix