### PR TITLE
ASGIRequest compatible middleware

### DIFF
--- a/django_hosts/middleware.py
+++ b/django_hosts/middleware.py
@@ -14,8 +14,10 @@ class HostsBaseMiddleware(MiddlewareMixin):
     new_hosts_middleware = 'django_hosts.middleware.HostsRequestMiddleware'
     toolbar_middleware = 'debug_toolbar.middleware.DebugToolbarMiddleware'
 
+    # TODO: when support for Django 3.2 is removed, replace with:
+    #   def __init__(self, get_response):
     def __init__(self, get_response=None):
-        self.get_response = get_response
+        super().__init__(get_response)
         self.current_urlconf = None
         self.host_patterns = get_host_patterns()
         try:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+5.1 (unreleased)
+----------------
+
+- Made middleware compatible with ASGI.
+
+  - This also fixes a bug that caused incompatibility with `channels
+    <https://pypi.org/project/channels/>`_ 3.0.0+.
+
 5.0 (2021-12-09)
 ----------------
 

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,7 +1,11 @@
+import asyncio
+
+from asgiref.sync import async_to_sync
 from django.http import HttpResponse
 from django.test import RequestFactory
 from django.test.utils import override_settings
 from django.core.exceptions import ImproperlyConfigured
+from django.utils.decorators import async_only_middleware
 
 from django_hosts.middleware import (HostsRequestMiddleware,
                                      HostsResponseMiddleware)
@@ -9,16 +13,26 @@ from django_hosts.middleware import (HostsRequestMiddleware,
 from .base import HostsTestCase
 
 
+def get_response_empty(request):
+    return HttpResponse()
+
+
+@async_only_middleware
+def async_middleware(get_response):
+    assert asyncio.iscoroutinefunction(get_response)
+    return get_response
+
+
 class MiddlewareTests(HostsTestCase):
 
     def test_missing_hostconf_setting(self):
         self.assertRaisesMessage(ImproperlyConfigured,
-            'Missing ROOT_HOSTCONF setting', HostsRequestMiddleware)
+            'Missing ROOT_HOSTCONF setting', HostsRequestMiddleware, get_response_empty)
 
     @override_settings(ROOT_HOSTCONF='tests.hosts.simple')
     def test_missing_default_hosts(self):
         self.assertRaisesMessage(ImproperlyConfigured,
-            'Missing DEFAULT_HOST setting', HostsRequestMiddleware)
+            'Missing DEFAULT_HOST setting', HostsRequestMiddleware, get_response_empty)
 
     @override_settings(
         ROOT_HOSTCONF='tests.hosts.simple',
@@ -26,7 +40,7 @@ class MiddlewareTests(HostsTestCase):
     def test_wrong_default_hosts(self):
         self.assertRaisesMessage(ImproperlyConfigured,
             "Invalid DEFAULT_HOST setting: No host called 'boo' exists",
-            HostsRequestMiddleware)
+            HostsRequestMiddleware, get_response_empty)
 
     @override_settings(
         ALLOWED_HOSTS=['other.example.com'],
@@ -35,7 +49,7 @@ class MiddlewareTests(HostsTestCase):
     def test_request_urlconf_module(self):
         rf = RequestFactory(HTTP_HOST='other.example.com')
         request = rf.get('/simple/')
-        middleware = HostsRequestMiddleware()
+        middleware = HostsRequestMiddleware(get_response_empty)
         middleware.process_request(request)
         self.assertEqual(request.urlconf, 'tests.urls.simple')
 
@@ -46,7 +60,7 @@ class MiddlewareTests(HostsTestCase):
     def test_response_urlconf_module(self):
         rf = RequestFactory(HTTP_HOST='other.example.com')
         request = rf.get('/simple/')
-        middleware = HostsResponseMiddleware()
+        middleware = HostsResponseMiddleware(get_response_empty)
         middleware.process_response(request, HttpResponse('test'))
         self.assertEqual(request.urlconf, 'tests.urls.simple')
 
@@ -57,7 +71,7 @@ class MiddlewareTests(HostsTestCase):
     def test_fallback_to_defaulthost(self):
         rf = RequestFactory(HTTP_HOST='ss.example.com')
         request = rf.get('/template/test/')
-        middleware = HostsRequestMiddleware()
+        middleware = HostsRequestMiddleware(get_response_empty)
         middleware.process_request(request)
         self.assertEqual(request.urlconf, 'tests.urls.complex')
         host, kwargs = middleware.get_host('non-existing')
@@ -79,6 +93,18 @@ class MiddlewareTests(HostsTestCase):
     @override_settings(
         ROOT_HOSTCONF='tests.hosts.simple',
         DEFAULT_HOST='www',
+        MIDDLEWARE=[
+            'django_hosts.middleware.HostsRequestMiddleware',
+            __module__ + '.async_middleware',
+            'django_hosts.middleware.HostsResponseMiddleware',
+        ])
+    @async_to_sync
+    async def test_asgi_request(self):
+        await self.async_client.get('/')
+
+    @override_settings(
+        ROOT_HOSTCONF='tests.hosts.simple',
+        DEFAULT_HOST='www',
         ALLOWED_HOSTS=['somehost.com'],
         DEBUG=False,
         MIDDLEWARE=[
@@ -96,7 +122,7 @@ class MiddlewareTests(HostsTestCase):
     def test_multiple_subdomains(self):
         rf = RequestFactory(HTTP_HOST='spam.eggs.example.com')
         request = rf.get('/multiple/')
-        middleware = HostsRequestMiddleware()
+        middleware = HostsRequestMiddleware(get_response_empty)
         middleware.process_request(request)
         self.assertEqual(request.urlconf, 'tests.urls.multiple')
 
@@ -114,4 +140,4 @@ class MiddlewareTests(HostsTestCase):
             'the django-debug-toolbar middleware in the MIDDLEWARE setting.'
         )
         with self.assertRaisesMessage(ImproperlyConfigured, msg):
-            HostsRequestMiddleware()
+            HostsRequestMiddleware(get_response_empty)

--- a/tests/test_sites.py
+++ b/tests/test_sites.py
@@ -1,4 +1,5 @@
 from django.contrib.sites.models import Site
+from django.http import HttpResponse
 from django.test import RequestFactory
 from django.test.utils import override_settings
 from django.utils.functional import empty
@@ -7,6 +8,10 @@ from django_hosts.middleware import HostsRequestMiddleware
 
 from .base import HostsTestCase
 from .models import Author, BlogPost, WikiPage
+
+
+def get_response_empty(request):
+    return HttpResponse()
 
 
 @override_settings(ALLOWED_HOSTS=['wiki.site1', 'wiki.site2', 'admin.site4', 'static'])
@@ -40,7 +45,7 @@ class SitesTests(HostsTestCase):
     def test_sites_callback(self):
         rf = RequestFactory(HTTP_HOST='wiki.site1')
         request = rf.get('/simple/')
-        middleware = HostsRequestMiddleware()
+        middleware = HostsRequestMiddleware(get_response_empty)
         middleware.process_request(request)
         self.assertEqual(request.urlconf, 'tests.urls.simple')
         self.assertEqual(request.site.pk, self.site1.pk)
@@ -51,7 +56,7 @@ class SitesTests(HostsTestCase):
     def test_sites_cached_callback(self):
         rf = RequestFactory(HTTP_HOST='admin.site4')
         request = rf.get('/simple/')
-        middleware = HostsRequestMiddleware()
+        middleware = HostsRequestMiddleware(get_response_empty)
         middleware.process_request(request)
 
         get_site = lambda: request.site.domain
@@ -72,7 +77,7 @@ class SitesTests(HostsTestCase):
     def test_sites_callback_with_parent_host(self):
         rf = RequestFactory(HTTP_HOST='wiki.site2')
         request = rf.get('/simple/')
-        middleware = HostsRequestMiddleware()
+        middleware = HostsRequestMiddleware(get_response_empty)
         middleware.process_request(request)
         self.assertEqual(request.urlconf, 'tests.urls.simple')
         self.assertEqual(request.site.pk, self.site2.pk)
@@ -83,7 +88,7 @@ class SitesTests(HostsTestCase):
     def test_manager_simple(self):
         rf = RequestFactory(HTTP_HOST='wiki.site2')
         request = rf.get('/simple/')
-        middleware = HostsRequestMiddleware()
+        middleware = HostsRequestMiddleware(get_response_empty)
         middleware.process_request(request)
         self.assertEqual(request.urlconf, 'tests.urls.simple')
         self.assertEqual(request.site.pk, self.site2.pk)
@@ -96,7 +101,7 @@ class SitesTests(HostsTestCase):
     def test_manager_missing_site(self):
         rf = RequestFactory(HTTP_HOST='static')
         request = rf.get('/simple/')
-        middleware = HostsRequestMiddleware()
+        middleware = HostsRequestMiddleware(get_response_empty)
         middleware.process_request(request)
         self.assertEqual(request.urlconf, 'tests.urls.simple')
         self.assertRaises(AttributeError, lambda: request.site)


### PR DESCRIPTION
Super call handles MiddlewareMixin._async_check() too.