### PR TITLE
Define in README what is path.to

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,8 +31,9 @@ at ``api.example.com`` and ``beta.example.com``, add the following to a
     )
 
 This causes requests to ``{api,beta}.example.com`` to be routed to their
-corresponding URLconf. You can use your ``urls.py`` as a template for these
-hostconfs.
+corresponding host URL conf file. Host URL conf file should define all routes which going to be hendled on a certain subdomain and has a same format like your plain ``urls.py`` (you can use it as a tamplate for your host URL confs). For example, requests to ``api.example.com`` will be mapped to views acording to `/path/to/api/urls.py` file
+
+
 
 Patterns are evaluated in order. If no pattern matches, the request is
 processed in the usual way, ie. using the standard ``ROOT_URLCONF``.


### PR DESCRIPTION
Probably you can somehow add path.to the description after the first occurrence (though I see that it is possible to understand what is it a tbottom)