### PR TITLE
docs: how to use with i18n_patterns

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -21,3 +21,101 @@ Also, you have to install `django-debug-toolbar 0.9.X`_ or higher.
 
 .. _`Django Debug toolbar`: https://github.com/django-debug-toolbar/django-debug-toolbar/
 .. _`django-debug-toolbar 0.9.X`: http://pypi.python.org/pypi/django-debug-toolbar
+
+How to use it with i18n?
+------------------------
+
+There are multiple approaches to use django-hosts together with :func:`~django.conf.urls.i18n.i18n_patterns`;
+here is one.
+
+Given a project using the :mod:`django.contrib.admin`, a mono-lingual blog and a multi-lingual website,
+each on their own subdomain, using a structure like::
+
+   ├── mysite
+   │   ├── hosts.py
+   │   ├── __init__.py
+   │   ├── settings.py
+   │   ├── urls.py
+   │   └── wsgi.py
+   ├── blog
+   │   ├── admin.py
+   │   ├── apps.py
+   │   ├── __init__.py
+   │   ├── models.py
+   │   ├── urls.py
+   │   └── views.py
+   └── www
+       ├── admin.py
+       ├── apps.py
+       ├── __init__.py
+       ├── models.py
+       ├── urls_i18n.py
+       ├── urls.py
+       └── views.py
+
+* :file:`mysite/settings.py`:
+
+  .. code-block:: python
+
+     # ...
+     ROOT_HOSTCONF = 'mysite.hosts'
+     DEFAULT_HOST = 'www'
+     PARENT_HOST = 'example.net'
+
+
+* :file:`mysite/hosts.py`:
+
+  .. code-block:: python
+
+     from django.conf import settings
+     from django_hosts import patterns, host
+
+     host_patterns = patterns(
+         '',
+         # will answer to www.example.net and example.net
+         host('(?:www|)', 'www.urls_i18n', name='www'),
+         # will answer to blog.example.net
+         host('blog', 'blog.urls', name='blog'),
+         # will answer to admin.example.net
+         host('admin', settings.ROOT_URLCONF, name='admin'),
+     )
+
+* :file:`mysite/urls.py`:
+
+  .. code-block:: python
+
+     from django.contrib import admin
+     from django.urls import include
+     from django.urls import path
+
+     urlpatterns = [
+         path('', admin.site.urls),
+         path('', include('blog.urls')),
+         path('', include('www.urls')),
+     ]
+
+* :file:`blog/urls.py`:
+
+  .. code-block:: python
+
+     from django.urls import path
+
+     from . import views
+
+     app_name = 'blog'
+
+     urlpatterns = [
+         path('', views.index, name='index'),
+     ]
+
+Reversing URL:
+
+.. code-block:: pycon
+
+   from django_hosts.resolvers import reverse
+   >>> reverse('admin:login', host='admin')
+   '//admin.example.net/login/'
+   >>> reverse('blog:index', host='blog')
+   '//blog.example.net/en-us/'
+   >>> reverse('www:index', host='www')
+   '//example.net/en-us/'


### PR DESCRIPTION
Using django-hosts together with the Djangos [language prefix in URL patterns](https://docs.djangoproject.com/en/3.2/topics/i18n/translation/#language-prefix-in-url-patterns) feature is a common use-case; unfortunately it is not straight-forward as using [`i18n_patterns`](https://docs.djangoproject.com/en/3.2/topics/i18n/translation/#django.conf.urls.i18n.i18n_patterns) within an included URLconf will throw an ImproperlyConfigured exception.

Here I suggest an implementation example, but I'm probably missing some points and I would like your enlightenment.

I also would like to add unit tests concerning this topic, but I was unable to setup the testing environment properly; I also kindly request your guidance on it.

Relates to:
- jazzband/django-hosts#68
- https://stackoverflow.com/q/66939490/248390
- https://stackoverflow.com/q/56389501/248390