### PR TITLE
Removed universal wheel from setup.cfg.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,9 +3,6 @@ django_find_project = false
 addopts = --cov django_hosts --cov-append --cov-report=xml --cov-report term-missing
 DJANGO_SETTINGS_MODULE = tests.settings
 
-[wheel]
-universal = 1
-
 [flake8]
 ignore = W504
 max-line-length = 119


### PR DESCRIPTION
Python 2 is not supported, so the wheel isn't universal.