### PR TITLE
Remove default_app_config

### DIFF
--- a/django_hosts/__init__.py
+++ b/django_hosts/__init__.py
@@ -10,5 +10,3 @@ except ImportError:  # pragma: no cover
 
 __version__ = pkg_resources.get_distribution('django-hosts').version
 __author__ = 'Jazzband members (https://jazzband.co/)'
-
-default_app_config = 'django_hosts.apps.HostsConfig'


### PR DESCRIPTION
default_app_config is [deprecated as of django 3.2](https://docs.djangoproject.com/en/3.2/releases/3.2/#automatic-appconfig-discovery), and will no longer
work with django 4.1

Since django 3.2 is now the lowest supported version of django-hosts, it
may be removed.