### PR TITLE
add GitHub URL for PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,9 @@ setup(
     python_requires='>=3.6',
     setup_requires=['setuptools_scm'],
     url='https://django-hosts.readthedocs.io/',
+    project_urls={
+        'Source': 'https://github.com/jazzband/django-hosts',
+    },
     author='Jannis Leidel',
     author_email='jannis@leidel.info',
     license='BSD',


### PR DESCRIPTION
Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help the automation tool find the source code for Requests.

Example: [pypi.org/pypi/requests/json](https://pypi.org/pypi/requests/json)
Docs: [packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls)