### PR TITLE
Switch pkg_resources to importlib.metadata to avoid DeprecationWarning

### DIFF
--- a/django_hosts/__init__.py
+++ b/django_hosts/__init__.py
@@ -1,5 +1,4 @@
-# flake8: noqa
-import pkg_resources
+from importlib.metadata import version
 
 try:  # pragma: no cover
     from django_hosts.defaults import patterns, host
@@ -8,5 +7,5 @@ try:  # pragma: no cover
 except ImportError:  # pragma: no cover
     pass
 
-__version__ = pkg_resources.get_distribution('django-hosts').version
+__version__ = version('django-hosts')
 __author__ = 'Jazzband members (https://jazzband.co/)'

--- a/django_hosts/defaults.py
+++ b/django_hosts/defaults.py
@@ -94,9 +94,7 @@ class host(object):
         The pattern is also suffixed by the PARENT_HOST setting if it exists.
         """
         self.regex = regex
-        parent_host = getattr(settings, 'PARENT_HOST', '').lstrip('.')
-        suffix = r'\.' + parent_host if parent_host else ''
-        self.compiled_regex = re.compile(r'%s%s(\.|:|$)' % (regex, suffix))
+        self.compiled_regex = re.compile(r'%s(\.|:|$)' % regex)
         self.urlconf = urlconf
         self.name = name
         self._scheme = scheme


### PR DESCRIPTION
With newer versions of Python, use of `pkg_resources` raises a `DeprecationWarning` (see for example [here](https://github.com/pypa/pip/issues/11975) and [here](https://github.com/pypa/setuptools/issues/2466)). From [Python 3.8 onward](https://docs.python.org/3/library/importlib.metadata.html#module-importlib.metadata) we can instead use `importlib.metadata`, which provides the `version` method directly.