### PR TITLE
Support Python 3.12 and drop 3.7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       max-parallel: 5
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       max-parallel: 5
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v2

--- a/django_hosts/__init__.py
+++ b/django_hosts/__init__.py
@@ -1,5 +1,5 @@
 # flake8: noqa
-import pkg_resources
+import importlib.metadata
 
 try:  # pragma: no cover
     from django_hosts.defaults import patterns, host
@@ -8,5 +8,5 @@ try:  # pragma: no cover
 except ImportError:  # pragma: no cover
     pass
 
-__version__ = pkg_resources.get_distribution('django-hosts').version
+__version__ = importlib.metadata.version('django-hosts')
 __author__ = 'Jazzband members (https://jazzband.co/)'

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,8 @@ Changelog
 X.Y (unreleased)
 ----------------
 
+- **BACKWARD-INCOMPATIBLE** Dropped support for Python 3.7.
+
 5.2 (2023-01-12)
 ----------------
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,8 @@ X.Y (unreleased)
 
 - **BACKWARD-INCOMPATIBLE** Dropped support for Python 3.7.
 
+- Confirmed support for Python 3.12.
+
 5.2 (2023-01-12)
 ----------------
 

--- a/setup.py
+++ b/setup.py
@@ -41,5 +41,6 @@ setup(
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
                 'Maps hostnames to URLconfs.',
     long_description=read('README.rst'),
     use_scm_version=True,
-    python_requires='>=3.6',
+    python_requires='>=3.8',
     setup_requires=['setuptools_scm'],
     url='https://django-hosts.readthedocs.io/',
     project_urls={
@@ -37,8 +37,6 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3 :: Only',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist =
     py{38,39,310}-dj32
     py{38,39,310}-dj40
     py{38,39,310,311}-dj41
-    py{310,311}-djmain
+    py{310,311,312}-djmain
 
 [testenv]
 usedevelop = true
@@ -27,3 +27,4 @@ python =
     3.9: py39
     3.10: py310
     3.11: py311
+    3.12: py312

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 downloadcache = {distshare}
 args_are_paths = false
 envlist =
-    py{37,38,39,310}-dj32
+    py{38,39,310}-dj32
     py{38,39,310}-dj40
     py{38,39,310,311}-dj41
     py{310,311}-djmain
@@ -23,7 +23,6 @@ deps =
 
 [gh-actions]
 python =
-    3.7: py37
     3.8: py38
     3.9: py39
     3.10: py310


### PR DESCRIPTION
As mentioned in this issue https://github.com/jazzband/django-hosts/issues/163 `pkg_resources` is deprecated and `importlib` should be used instead. Putting out this PR as this is blocking our upgrade to Python 3.12