### PR TITLE
Confirm support for Django 4.2 and 5.0, drop support for 4.0 and 4.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ docs/_build
 *.egg-info
 *.egg
 .coverage
+coverage.xml
 reports/
 build/
 dist/

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,7 +4,7 @@ Changelog
 X.Y (unreleased)
 ----------------
 
-- **BACKWARD-INCOMPATIBLE** Dropped support Django 4.0 and 4.1.
+- **BACKWARD-INCOMPATIBLE** Dropped support Django < 4.2.
 
 - Confirmed support for Django 4.2 and 5.0 (no code changes were required).
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,8 @@ Changelog
 X.Y (unreleased)
 ----------------
 
+- **BACKWARD-INCOMPATIBLE** Dropped support Django 4.0 and 4.1.
+
 - Confirmed support for Django 4.2 and 5.0 (no code changes were required).
 
 6.0 (2023-10-27)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,8 @@ Changelog
 X.Y (unreleased)
 ----------------
 
+- Confirmed support for Django 4.2 and 5.0 (no code changes were required).
+
 6.0 (2023-10-27)
 ----------------
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 import codecs
 from os import path
-from setuptools import setup, find_packages
+
+from setuptools import find_packages, setup
 
 
 def read(*parts):
@@ -31,6 +32,8 @@ setup(
         'Framework :: Django :: 3.2',
         'Framework :: Django :: 4.0',
         'Framework :: Django :: 4.1',
+        'Framework :: Django :: 4.2',
+        'Framework :: Django :: 5.0',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,6 @@ setup(
         'Development Status :: 5 - Production/Stable',
         'Environment :: Web Environment',
         'Framework :: Django',
-        'Framework :: Django :: 3.2',
         'Framework :: Django :: 4.2',
         'Framework :: Django :: 5.0',
         'Intended Audience :: Developers',

--- a/setup.py
+++ b/setup.py
@@ -30,8 +30,6 @@ setup(
         'Environment :: Web Environment',
         'Framework :: Django',
         'Framework :: Django :: 3.2',
-        'Framework :: Django :: 4.0',
-        'Framework :: Django :: 4.1',
         'Framework :: Django :: 4.2',
         'Framework :: Django :: 5.0',
         'Intended Audience :: Developers',

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,8 @@ envlist =
     py{38,39,310}-dj32
     py{38,39,310}-dj40
     py{38,39,310,311}-dj41
+    py{38,39,310,311,312}-dj42
+    py{310,311,312}-dj50
     py{310,311,312}-djmain
 
 [testenv]
@@ -12,9 +14,11 @@ usedevelop = true
 commands = make test
 allowlist_externals = make
 deps =
-    dj32: Django>=3.2a1,<4.0
-    dj40: Django>=4.0a1,<4.1
-    dj41: Django>=4.1a1,<4.2
+    dj32: Django>=3.2,<4.0
+    dj40: Django>=4.0,<4.1
+    dj41: Django>=4.1,<4.2
+    dj42: Django>=4.2,<5.0
+    dj50: Django>=5.0,<5.1
     djmain: https://github.com/django/django/tarball/main
     coverage
     flake8

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,6 @@
 downloadcache = {distshare}
 args_are_paths = false
 envlist =
-    py{38,39,310}-dj32
     py{38,39,310,311,312}-dj42
     py{310,311,312}-dj50
     py{310,311,312}-djmain
@@ -12,7 +11,6 @@ usedevelop = true
 commands = make test
 allowlist_externals = make
 deps =
-    dj32: Django>=3.2,<4.0
     dj42: Django>=4.2,<5.0
     dj50: Django>=5.0,<5.1
     djmain: https://github.com/django/django/tarball/main

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,6 @@ downloadcache = {distshare}
 args_are_paths = false
 envlist =
     py{38,39,310}-dj32
-    py{38,39,310}-dj40
-    py{38,39,310,311}-dj41
     py{38,39,310,311,312}-dj42
     py{310,311,312}-dj50
     py{310,311,312}-djmain
@@ -15,8 +13,6 @@ commands = make test
 allowlist_externals = make
 deps =
     dj32: Django>=3.2,<4.0
-    dj40: Django>=4.0,<4.1
-    dj41: Django>=4.1,<4.2
     dj42: Django>=4.2,<5.0
     dj50: Django>=5.0,<5.1
     djmain: https://github.com/django/django/tarball/main


### PR DESCRIPTION
Add Django 4.2 and 5.0 to the test matrix, as they've been released for a while. Python versions supported by each Django version: https://docs.djangoproject.com/en/dev/faq/install/#what-python-version-can-i-use-with-django