### PR TITLE
Add RTD config file

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,14 @@
+# Read the Docs configuration file for Sphinx projects
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+version: 2
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.12"
+
+sphinx:
+  configuration: docs/conf.py
+
+python:
+ install:
+   - requirements: docs/requirements.txt


### PR DESCRIPTION
As per #135 adding the config file for read the docs.

Someone with admin access might have to re-enable webhooks from here https://readthedocs.org/dashboard/django-hosts/integrations/

You can get [a preview of the docs on each PR](https://docs.readthedocs.io/en/stable/pull-requests.html) by ticking this checkbox on this page https://readthedocs.org/dashboard/django-hosts/edit/ 

![image](https://github.com/jazzband/django-hosts/assets/861044/7d480797-c5d1-4ad7-abfa-378717f32e3f)
