### PR TITLE
Refresh hostconf on `ROOT_URLCONF` change

### DIFF
--- a/django_hosts/resolvers.py
+++ b/django_hosts/resolvers.py
@@ -65,7 +65,7 @@ def clear_host_caches():
 
 
 def setting_changed_receiver(setting, enter, **kwargs):
-    if setting in {'ROOT_HOSTCONF', 'DEFAULT_HOST'}:
+    if setting in {'ROOT_HOSTCONF', 'DEFAULT_HOST', 'ROOT_URLCONF'}:
         clear_host_caches()
 
 


### PR DESCRIPTION
It is a common scenario to use `settings.ROOT_URLCONF` in hostconf, e.g.
```python
host_patterns = [
    host(r"www", settings.ROOT_URLCONF, name="www"),
]
```
If a developer wants to test a different urlconf, the hostconf won't refresh and this can be problematic. For this reason I suggest to reload hostconf on `ROOT_URLCONF` change as well.