### PR TITLE
Update documentation links and fix typos

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@ django-hosts
 ============
 
 .. image:: https://img.shields.io/pypi/v/django-hosts.svg
-   :target: https://pypi.python.org/pypi/django-hosts
+   :target: https://pypi.org/project/django-hosts/
 
 .. image:: https://img.shields.io/pypi/pyversions/django-hosts.svg
    :target: https://pypi.org/project/django-hosts/
@@ -14,7 +14,7 @@ django-hosts
    :target: https://github.com/jazzband/django-hosts/actions
 
 .. image:: https://codecov.io/gh/jazzband/django-hosts/branch/master/graph/badge.svg
-   :target: https://codecov.io/gh/jazzband/django-hosts
+   :target: https://app.codecov.io/gh/jazzband/django-hosts
 
 .. image:: https://readthedocs.org/projects/django-hosts/badge/?version=latest&style=flat
    :target: https://django-hosts.readthedocs.io/en/latest/

--- a/django_hosts/resolvers.py
+++ b/django_hosts/resolvers.py
@@ -149,7 +149,7 @@ def reverse(viewname, args=None, kwargs=None, prefix=None, current_app=None,
         'git://jezdez.example.com:1337/repo/'
 
     You can set the used port and scheme in the host object or override with
-    the paramater named accordingly.
+    the parameter named accordingly.
 
     The host name can be left empty to automatically fall back to the default
     hostname as defined in the :attr:`~django.conf.settings.DEFAULT_HOST`

--- a/django_hosts/templatetags/hosts.py
+++ b/django_hosts/templatetags/hosts.py
@@ -109,7 +109,7 @@ def fetch_arg(name, arg, bits, consume=True):
 @register.tag
 def host_url(parser, token):
     """
-    Simple tag to reverse the URL inclusing a host.
+    Simple tag to reverse the URL including a host.
 
     {% host_url 'view-name' host 'host-name'  %}
     {% host_url 'view-name' host 'host-name' 'spam' %}

--- a/docs/callbacks.rst
+++ b/docs/callbacks.rst
@@ -20,7 +20,7 @@ Simply define a callback function:
     def custom_fn(request, username):
         request.viewing_user = get_object_or_404(User, username=username)
 
-..and pass it as the ``callback`` paramter to the ``host`` object:
+..and pass it as the ``callback`` parameter to the ``host`` object:
 
 .. code-block:: python
 

--- a/docs/callbacks.rst
+++ b/docs/callbacks.rst
@@ -83,4 +83,4 @@ contrib app ``django.contrib.sites``:
 
 .. autofunction:: django_hosts.callbacks.cached_host_site(request, *args, **kwargs)
 
-.. _DRY: http://de.wikipedia.org/wiki/Don’t_repeat_yourself
+.. _DRY: https://de.wikipedia.org/wiki/Don’t_repeat_yourself

--- a/docs/callbacks.rst
+++ b/docs/callbacks.rst
@@ -83,4 +83,4 @@ contrib app ``django.contrib.sites``:
 
 .. autofunction:: django_hosts.callbacks.cached_host_site(request, *args, **kwargs)
 
-.. _DRY: https://de.wikipedia.org/wiki/Don’t_repeat_yourself
+.. _DRY: https://en.wikipedia.org/wiki/Don%27t_repeat_yourself

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -10,12 +10,12 @@ django-hosts' ``HostsRequestMiddleware`` middleware, e.g.:
 
 .. code-block:: python
 
-    MIDDLEWARE = (
+    MIDDLEWARE = [
         'django_hosts.middleware.HostsRequestMiddleware',
         # your other middlewares..
         'debug_toolbar.middleware.DebugToolbarMiddleware',
         'django_hosts.middleware.HostsResponseMiddleware',
-    )
+    ]
 
 Also, you have to install `django-debug-toolbar 0.9.X`_ or higher.
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -20,7 +20,7 @@ django-hosts' ``HostsRequestMiddleware`` middleware, e.g.:
 Also, you have to install `django-debug-toolbar 0.9.X`_ or higher.
 
 .. _`Django Debug toolbar`: https://github.com/django-debug-toolbar/django-debug-toolbar/
-.. _`django-debug-toolbar 0.9.X`: http://pypi.python.org/pypi/django-debug-toolbar
+.. _`django-debug-toolbar 0.9.X`: https://pypi.python.org/pypi/django-debug-toolbar
 
 
 My tests using client.post(...) are failing now, what should I do?

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -20,7 +20,7 @@ django-hosts' ``HostsRequestMiddleware`` middleware, e.g.:
 Also, you have to install `django-debug-toolbar 0.9.X`_ or higher.
 
 .. _`Django Debug toolbar`: https://github.com/django-debug-toolbar/django-debug-toolbar/
-.. _`django-debug-toolbar 0.9.X`: https://pypi.python.org/pypi/django-debug-toolbar
+.. _`django-debug-toolbar 0.9.X`: https://pypi.org/project/django-debug-toolbar/
 
 
 My tests using client.post(...) are failing now, what should I do?

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -137,6 +137,6 @@ Thanks
 Many thanks to the folks at playfire_ for releasing their
 django-dynamic-subdomains_ app, which was the inspiration for this app.
 
-.. _playfire: http://code.playfire.com/
+.. _playfire: https://playfire.com/
 .. _django-dynamic-subdomains: https://github.com/playfire/django-dynamic-subdomains/
 .. _`Github issue tracker`: https://github.com/jazzband/django-hosts/issues

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -137,6 +137,6 @@ Thanks
 Many thanks to the folks at playfire_ for releasing their
 django-dynamic-subdomains_ app, which was the inspiration for this app.
 
-.. _playfire: https://playfire.com/
+.. _playfire: https://web.archive.org/web/20110514020134/http://code.playfire.com/
 .. _django-dynamic-subdomains: https://github.com/playfire/django-dynamic-subdomains/
 .. _`Github issue tracker`: https://github.com/jazzband/django-hosts/issues

--- a/docs/templatetags.rst
+++ b/docs/templatetags.rst
@@ -191,5 +191,5 @@ result of the template tag in a template variable and use it later on, e.g.:
     <a href="{{ homepage_url }}" title="Go back to {{ homepage_url }}">Home</a>
 
 
-.. _The protocol-relative URL: http://paulirish.com/2010/the-protocol-relative-url/
-.. _section in RFC 3986: http://tools.ietf.org/html/rfc3986#section-4.2
+.. _The protocol-relative URL: https://www.paulirish.com/2010/the-protocol-relative-url/
+.. _section in RFC 3986: https://datatracker.ietf.org/doc/html/rfc3986#section-4.2


### PR DESCRIPTION
Updates documentation links and corrects some minor typos.

I wasn't sure what to do with the playfire link as they were bought by Green Man Gaming and since shut down (looking at the timeline this happened after this fork).